### PR TITLE
Default to using resource/url for all references

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -2436,11 +2436,8 @@ public class FhirStu3 {
     BundleEntryComponent entry = bundle.addEntry();
 
     resource.setId(resourceID);
-    if (Boolean.parseBoolean(Config.get("exporter.fhir.bulk_data"))) {
-      entry.setFullUrl(resource.fhirType() + "/" + resourceID);
-    } else {
-      entry.setFullUrl("urn:uuid:" + resourceID);
-    }
+    entry.setFullUrl(resource.fhirType() + "/" + resourceID);
+
     entry.setResource(resource);
 
     if (TRANSACTION_BUNDLE) {


### PR DESCRIPTION
Setting exporter.fhir.bulk_data in the synthea.properties will export the resources with the correct reference format, however it will also cause the exports to be in NDJSON. This fix defaults reference formats to be in the format of <TYPE>/Reference_id as we have no known need for the urn:uuid style format.

You can test this PR by running synthea eg: `./run_synthea -p 10` and checking the format of the 'reference:' fields on the patient and within the entries on the patient

Ticket: https://jira.mitre.org/browse/TACOSTRAT-349