### PR TITLE
Exm 104 r4

### DIFF
--- a/src/main/resources/modules/stroke_exm_104_r4.json
+++ b/src/main/resources/modules/stroke_exm_104_r4.json
@@ -1,5 +1,5 @@
 {
-  "name": "exm_104",
+  "name": "exm_104_r4",
   "remarks": [
     "a non clinically-accurate stroke encounter module, for use with EXM104"
   ],

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -5,7 +5,7 @@ exporter.use_uuid_filenames = false
 exporter.subfolders_by_id_substring = false
 # number of years of history to keep in exported records, anything older than this may be filtered out
 # set years_of_history = 0 to skip filtering altogether and keep the entire history
-exporter.years_of_history = 10
+exporter.years_of_history = 2
 # split records allows patients to have one record per provider organization
 exporter.split_records = false
 exporter.split_records.duplicate_data = false


### PR DESCRIPTION
This branch:

* Turns down the number of stroke encounters in `stroke_exm_104` per patient, by making them wait longer to get strokes and making them wait an extra half a year (on average) between strokes
* Duplicates that module into `stroke_exm_104_r4`, and changes the module name
* Adds support to the R4 exporter for some needed attributes on `MedicationRequest` to convince the measure that it's actually a Discharge medication