### PR TITLE
Add helper class for resolving ValueSets

### DIFF
--- a/src/main/java/org/mitre/synthea/helpers/ValueSetResolver.java
+++ b/src/main/java/org/mitre/synthea/helpers/ValueSetResolver.java
@@ -1,0 +1,65 @@
+package org.mitre.synthea.helpers;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.json.simple.JSONObject;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+
+/*
+ * Helper class for resolving FHIR ValueSet resources from a JSON file
+ */
+public class ValueSetResolver {
+  private JSONParser jsonParser;
+  private IParser fhirParser;
+  private String filePath;
+
+  public ValueSetResolver(String filePath) {
+    FhirContext ctx = FhirContext.forR4();
+    this.jsonParser = new JSONParser();
+    this.fhirParser = ctx.newJsonParser();
+    this.filePath = filePath;
+  }
+
+  private Bundle parseValueSetBundle() throws FileNotFoundException, IOException, ParseException {
+    JSONObject jsonBundle = (JSONObject) this.jsonParser.parse(new FileReader(this.filePath));
+    String bundleString = jsonBundle.toString();
+    Bundle bundle = fhirParser.parseResource(Bundle.class, bundleString);
+    return bundle;
+  }
+
+  /**
+   * Get ValueSet resource that match an OID in the list of desired ones
+   * 
+   * @param desiredOIDs List of OIDs to match against
+   * @return List of ValueSet resources that match the desired OIDs
+   */
+  public List<ValueSet> getValueSets(List<String> desiredOIDs) {
+    try {
+      Bundle vsetBundle = this.parseValueSetBundle();
+      List<ValueSet> matchingValueSets = new ArrayList<ValueSet>();
+      
+      // Check each identifier and add to list if matches
+      for (BundleEntryComponent e : vsetBundle.getEntry()) {
+        ValueSet vset = (ValueSet) e.getResource();
+        String oid = vset.getIdentifierFirstRep().getValue();
+        if (oid != null && desiredOIDs.contains(oid)) {
+          matchingValueSets.add(vset);
+        }
+      }
+
+      return matchingValueSets;
+    } catch (IOException | ParseException e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
+}

--- a/src/main/java/org/mitre/synthea/helpers/ValueSetResolver.java
+++ b/src/main/java/org/mitre/synthea/helpers/ValueSetResolver.java
@@ -1,20 +1,20 @@
 package org.mitre.synthea.helpers;
 
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-import org.json.simple.JSONObject;
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.ValueSet;
-import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.parser.IParser;
 
 /*
  * Helper class for resolving FHIR ValueSet resources from a JSON file
@@ -24,8 +24,13 @@ public class ValueSetResolver {
   private IParser fhirParser;
   private String filePath;
 
-  final Pattern OID_REGEX = Pattern.compile("([0-9]+\\.)+[0-9]+");
+  static final Pattern OID_REGEX = Pattern.compile("([0-9]+\\.)+[0-9]+");
 
+  /**
+   * Construct a new ValueSetResolver object.
+   *
+   * @param filePath absolute path to a Bundle of ValueSets as a JSON file
+   */
   public ValueSetResolver(String filePath) {
     FhirContext ctx = FhirContext.forR4();
     this.jsonParser = new JSONParser();
@@ -40,8 +45,10 @@ public class ValueSetResolver {
     return bundle;
   }
 
-  private String matchOID(String input) {
-    if (input == null) return null;
+  private String matchOid(String input) {
+    if (input == null) {
+      return null;
+    }
 
     Matcher m = OID_REGEX.matcher(input);
 
@@ -53,36 +60,37 @@ public class ValueSetResolver {
   }
 
   /**
-   * Get ValueSet resource that match an OID in the list of desired ones
+   * Get ValueSet resource that match an OID in the list of desired ones.
    * 
-   * @param desiredOIDs List of OIDs to match against
+   * @param desiredOids List of OIDs to match against
    * @return List of ValueSet resources that match the desired OIDs
    * @throws ParseException when unable to parse ValueSet bundle into JSON
    * @throws IOException when unable to read in file
    * @throws FileNotFoundException when provided an invalid path to ValueSet Bundle
    * @throws RuntimeException when ValueSet is not found
    */
-  public List<ValueSet> getValueSets(List<String> desiredOIDs) throws FileNotFoundException, IOException, ParseException {
+  public List<ValueSet> getValueSets(List<String> desiredOids)
+      throws FileNotFoundException, IOException, ParseException {
     Bundle vsetBundle = this.parseValueSetBundle();
     List<ValueSet> matchingValueSets = new ArrayList<ValueSet>();
 
     // Check each identifier and add to list if matches
-    for (String oid : desiredOIDs) {
-      String desiredOID = this.matchOID(oid);
+    for (String oid : desiredOids) {
+      String desiredOid = this.matchOid(oid);
 
-      boolean foundMatchingOID = false;
+      boolean foundMatchingOid = false;
       for (BundleEntryComponent e : vsetBundle.getEntry()) {
         ValueSet vset = (ValueSet) e.getResource();
-        String knownOID = this.matchOID(vset.getIdentifierFirstRep().getValue());
+        String knownOid = this.matchOid(vset.getIdentifierFirstRep().getValue());
 
-        if (knownOID != null && knownOID.equals(desiredOID)) {
+        if (knownOid != null && knownOid.equals(desiredOid)) {
           matchingValueSets.add(vset);
-          foundMatchingOID = true;
+          foundMatchingOid = true;
           break;
         }
       }
 
-      if (!foundMatchingOID) {
+      if (!foundMatchingOid) {
         throw new RuntimeException(String.format("Could not resolve ValueSet %s", oid));
       }
     }


### PR DESCRIPTION
Adds a helper class that does the following:

* Takes in the path to a static file (for now), that is a Bundle of ValueSet resources, and parses it into a `org.hl7.fhir.r4.model.Bundle` Java object.
* Exposes a function that can take in a `List<String>` of ValueSet oids, and search the bundle for ValueSet resources that match any of those oids.
  * It will return a `List<ValueSet>` back to the caller.

Here is a Java snippet I used to test this code: 

``` Java
package org.mitre.synthea.helpers;

import java.util.List;
import java.util.ArrayList;
import org.hl7.fhir.r4.model.ValueSet;

public class Main {
  public static void main(String[] args) {
    List<String> oids = new ArrayList<String>();
    oids.add("2.16.840.1.113883.3.464.1003.108.12.1020");
    oids.add("2.16.840.1.113883.3.464.1003.198.12.1010");
    ValueSetResolver vs = new ValueSetResolver("/absolute/path/to/a/bundle/valuesets");
    List<ValueSet> vsets = vs.getValueSets(oids); // can inspect this with printlns or debugger or whatever you want
  }
}
```
