### PR TITLE
Add a ValueSet resource to the GMF side of Synthea

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -4,10 +4,12 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -261,6 +263,17 @@ public class Generator {
     return modules.stream()
             .map(m -> m.name)
             .collect(Collectors.toList());
+  }
+
+  /**
+   * Extracts a Set of ValueSet URLs from a List of Modules (which gets them from its embedded States)
+   * @param modules a collection of Modules
+   * @return a Set of ValueSet URLs
+   */
+  private Set<String> getValueSetUrls(List<Module> modules) {
+    return modules.stream()
+      .flatMap(m -> m.getValueSetUrls().stream())
+      .collect(Collectors.toSet());
   }
   
   /**

--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -255,6 +255,7 @@ public class Generator {
 
   /**
    * Extracts a list of names from the supplied list of modules.
+   *
    * @param modules A collection of modules
    * @return A list of module names.
    */
@@ -265,7 +266,9 @@ public class Generator {
   }
 
   /**
-   * Extracts a Set of ValueSet URLs from a List of Modules (which gets them from its embedded States)
+   * Extracts a Set of ValueSet URLs from a List of Modules
+   * (which gets them from its embedded States).
+   *
    * @param modules a collection of Modules
    * @return a Set of ValueSet URLs
    */

--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -21,17 +21,20 @@ import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.Utilities;
@@ -356,6 +359,16 @@ public class Module {
       return Collections.emptySet();
     }
     return states.keySet();
+  }
+
+  public Set<String> getValueSetUrls() {
+    if (states != null) {
+      return states.values().stream()
+        .filter(s -> s.valueset != null)
+        .map(s-> s.valueset.url)
+        .collect(Collectors.toSet());
+    }
+    return new HashSet<String>();
   }
 
   /**

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -350,7 +350,7 @@ public class Module {
 
   /**
    * Get a collection of the names of all the states this Module contains.
-   * 
+   *
    * @return set of all state names, or empty set if this is a non-GMF module
    */
   public Collection<String> getStateNames() {
@@ -361,11 +361,16 @@ public class Module {
     return states.keySet();
   }
 
+  /**
+   * Gets all the non-null valueset URLs from the states in this Module.
+   *
+   * @return Set with all the unique valueset URLs
+   */
   public Set<String> getValueSetUrls() {
     if (states != null) {
       return states.values().stream()
         .filter(s -> s.valueset != null)
-        .map(s-> s.valueset.url)
+        .map(s -> s.valueset.url)
         .collect(Collectors.toSet());
     }
     return new HashSet<String>();

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -41,6 +41,7 @@ import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
 import org.mitre.synthea.world.concepts.HealthRecord.Entry;
 import org.mitre.synthea.world.concepts.HealthRecord.Medication;
 import org.mitre.synthea.world.concepts.HealthRecord.Report;
+import org.mitre.synthea.world.concepts.HealthRecord.ValueSet;
 import org.simulator.math.odes.MultiTable;
 
 public abstract class State implements Cloneable {
@@ -58,6 +59,8 @@ public abstract class State implements Cloneable {
   private List<ComplexTransitionOption> complexTransition;
   private List<LookupTableTransitionOption> lookupTableTransition;
   public List<String> remarks;
+
+  public ValueSet valueset; // This is included at the top level for ease of computation
 
   protected void initialize(Module module, String name, JsonObject definition) {
     this.module = module;
@@ -117,6 +120,7 @@ public abstract class State implements Cloneable {
       clone.name = this.name;
       clone.transition = this.transition;
       clone.remarks = this.remarks;
+      clone.valueset = this.valueset;
       return clone;
     } catch (CloneNotSupportedException e) {
       // should not happen, and not something we can handle

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Clinician;
@@ -93,6 +92,57 @@ public class HealthRecord {
       if (compare == 0) {
         compare = this.code.compareTo(other.code);
       }
+      return compare;
+    }
+  }
+
+  /**
+   * HealthRecord.ValueSet represents a valueset URL and display name.
+   */
+  public static class ValueSet implements Comparable<ValueSet> {
+    /** The ValueSet URL. */
+    public String url;
+    /** The human-readable description of the ValueSet. */
+    public String display;
+
+    /**
+     * Create a new ValueSet.
+     *
+     * @param url    the valueset URL
+     * @param display human-readable description of the coe
+     */
+    public ValueSet(String url, String display) {
+      this.url = url;
+      this.display = display;
+    }
+
+    /**
+     * Create a new ValueSet from JSON.
+     *
+     * @param definition JSON object that contains 'url', and 'display'
+     *                   attributes.
+     */
+    public ValueSet(JsonObject definition) {
+      this.url = definition.get("url").getAsString();
+      this.display = definition.get("display").getAsString();
+    }
+
+    public boolean equals(ValueSet other) {
+      return this.url.equals(other.url);
+    }
+
+    public String toString() {
+      return String.format("%s %s", url, display);
+    }
+
+    public static ValueSet fromJson(JsonObject jsonValueSet) {
+      ValueSet vs = new ValueSet(jsonValueSet);
+      return vs;
+    }
+
+    @Override
+    public int compareTo(ValueSet other) {
+      int compare = this.url.compareTo(other.url);
       return compare;
     }
   }

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -108,8 +108,8 @@ public class HealthRecord {
     /**
      * Create a new ValueSet.
      *
-     * @param url    the valueset URL
-     * @param display human-readable description of the coe
+     * @param url     the valueset URL
+     * @param display human-readable description of the code
      */
     public ValueSet(String url, String display) {
       this.url = url;


### PR DESCRIPTION
Also enables rollup of valueset URL attributes to the Generator level for resolution.

To test:
* Pick a couple of modules, and add a `valueset` attribute to the Module JSON for some states in those modules. That state will look like:
```json
"valueset": {
  "url": "urn:oid:2.13.840.1.113883.<the rest of your oid>",
  "display": "A valueset name"
}
```
Note that `valueset` has to be capitalized exactly as shown above in the JSON, because of the way Synthea deserializes the modules.
For best testing purposes, add a couple of valuesets where the URL is the same, and a couple of different ones.
* Go into `src/main/java/org/mitre/synthea/engine/Generator.java`, and add a line in `init()` (I added mine after line `224`) like the following:
```java
  System.out.println(getValueSetUrls(Module.getModules(modulePredicate)));
```
This will print out a list of all unique valuesets in the modules.

NOTE: If you delete the `code` attributes while adding the `valueset` ones, the generator will break without generating any patients. Also, this PR does not include code to resolve the valuesets from these URLs, nor the code to pick random `code` objects out of said valuesets; both of these tasks are out-of-scope.