### PR TITLE
Arbitrary attribute support

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -858,6 +858,7 @@ public abstract class State implements Cloneable {
       String primaryCode = codes.get(0).code;
       entry = person.record.conditionStart(time, primaryCode);
       entry.name = this.name;
+      entry.additionalAttributes = this.additionalAttributes;
       if (codes != null) {
         entry.codes.addAll(codes);
       }
@@ -923,6 +924,7 @@ public abstract class State implements Cloneable {
       entry = person.record.allergyStart(time, primaryCode);
       entry.name = this.name;
       entry.codes.addAll(codes);
+      entry.additionalAttributes = this.additionalAttributes;
 
       if (assignToAttribute != null) {
         person.attributes.put(assignToAttribute, entry);

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -61,6 +61,7 @@ public abstract class State implements Cloneable {
   public List<String> remarks;
 
   public ValueSet valueset; // This is included at the top level for ease of computation
+  public JsonObject additionalAttributes;
 
   protected void initialize(Module module, String name, JsonObject definition) {
     this.module = module;
@@ -121,6 +122,7 @@ public abstract class State implements Cloneable {
       clone.transition = this.transition;
       clone.remarks = this.remarks;
       clone.valueset = this.valueset;
+      clone.additionalAttributes = this.additionalAttributes;
       return clone;
     } catch (CloneNotSupportedException e) {
       // should not happen, and not something we can handle
@@ -659,6 +661,7 @@ public abstract class State implements Cloneable {
         }
         person.setCurrentEncounter(module, encounter);
         encounter.name = this.name;
+        encounter.additionalAttributes = additionalAttributes;
 
         diagnosePastConditions(person, time);
 
@@ -1006,6 +1009,7 @@ public abstract class State implements Cloneable {
       entry = medication;
       medication.name = this.name;
       medication.codes.addAll(codes);
+      medication.additionalAttributes = this.additionalAttributes;
 
       if (reason != null) {
         // "reason" is an attribute or stateName referencing a previous conditionOnset state
@@ -1118,6 +1122,7 @@ public abstract class State implements Cloneable {
       entry = careplan;
       careplan.name = this.name;
       careplan.codes.addAll(codes);
+      careplan.additionalAttributes = this.additionalAttributes;
 
       if (activities != null) {
         careplan.activities.addAll(activities);
@@ -1216,6 +1221,7 @@ public abstract class State implements Cloneable {
       entry = procedure;
       procedure.name = this.name;
       procedure.codes.addAll(codes);
+      procedure.additionalAttributes = this.additionalAttributes;
 
       if (reason != null) {
         // "reason" is an attribute or stateName referencing a previous conditionOnset state
@@ -1418,6 +1424,7 @@ public abstract class State implements Cloneable {
       observation.codes.addAll(codes);
       observation.category = category;
       observation.unit = unit;
+      observation.additionalAttributes = this.additionalAttributes;
 
       return true;
     }
@@ -1470,6 +1477,7 @@ public abstract class State implements Cloneable {
       observation.name = this.name;
       observation.codes.addAll(codes);
       observation.category = category;
+      observation.additionalAttributes = this.additionalAttributes;
 
       return true;
     }
@@ -1493,6 +1501,7 @@ public abstract class State implements Cloneable {
       entry = report;
       report.name = this.name;
       report.codes.addAll(codes);
+      report.additionalAttributes = this.additionalAttributes;
 
       // increment number of labs by respective provider
       Provider provider;
@@ -1553,6 +1562,7 @@ public abstract class State implements Cloneable {
       procedure.name = this.name;
       procedure.codes.add(procedureCode);
       procedure.stop = procedure.start + TimeUnit.MINUTES.toMillis(30);
+      procedure.additionalAttributes = this.additionalAttributes;
       return true;
     }
 

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -161,6 +161,7 @@ public class HealthRecord {
     public long stop;
     public String type;
     public List<Code> codes;
+    public JsonObject additionalAttributes;
     private BigDecimal cost;
 
     /**


### PR DESCRIPTION
## Summary

The attributes are just stored as a JSON object in order to support arbitrary object structure. It will be up to the exporter to do more sophisticated processing of this object if/when there are cases where that is necessary.

At first with this task I went down the road of trying to come up with more elaborate deserialization, AKA attempting to deserialize things into their actual types when possible. I later came to the conclusion that that gave little-to-no-benefit at the cost of complexity and so this approach made more sense. Please let me know if you think I missed the mark and there's a better way to do this.

## To Test
- I pushed up a test branch [`arbitrary_attributes_test`](https://github.com/projecttacoma/synthea/compare/arbitrary_attributes...projecttacoma:arbitrary_attributes_test) off of this one that has code to test that this does what it should.
- Pull that branch and run Synthea like: `./run_synthea -p 10 -a 51-51 -m "EXM130-r4*"`
- You should see the arbitrary attribute JSON Object printed to the console for each patient that has it. (Note that you will not find it in the actual exported FHIR patient yet)
- If you want to try modifying the `additional_attributes` object, it should work with any arbitrary JSON object.