### PR TITLE
exm506 r4 module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ src/main/resources/version.txt
 
 # eCQM ValueSets
 src/main/resources/terminology/*
+!src/main/resources/terminology/.gitkeep

--- a/src/main/resources/modules/EXM130-r4.json
+++ b/src/main/resources/modules/EXM130-r4.json
@@ -41,10 +41,13 @@
         ],
         "type": "Encounter",
         "encounter_class": "ambulatory",
-        "valueset": {
-          "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001",
-          "display": "Office Visit"
-        },
+        "codes": [
+          {
+              "system": "http://snomed.info/sct",
+              "code": "185465003",
+              "display": "Weekend visit (procedure)"
+          }
+        ],
         "distributed_transition": [
           {
             "distribution": 0.5,
@@ -66,10 +69,13 @@
           "  and Global.'Normalize Onset'(Colonoscopy.performed) ends 10 years or less on or before end of 'Measurement Period'",
           "============================================================================================================================"
         ],
-        "valueset": {
-          "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020",
-          "display": "Colonoscopy"
-        },
+        "codes": [
+          {
+            "system": "SNOMED-CT",
+            "code": "73761001",
+            "display": "Colonoscopy"
+          }
+        ],
         "direct_transition": "Terminal"
       },
       "Terminal": {

--- a/src/main/resources/modules/EXM506-r4.json
+++ b/src/main/resources/modules/EXM506-r4.json
@@ -59,7 +59,16 @@
     },
     "Hospital_Stay_End": {
       "type": "EncounterEnd",
-      "direct_transition": "Medication_End"
+      "distributed_transition": [
+        {
+          "transition": "Terminal",
+          "distribution": 0.01
+        },
+        {
+          "transition": "Hospital_Encounter_Delay",
+          "distribution": 0.99
+        }
+      ]
     },
     "Age_Guard": {
       "type": "Guard",
@@ -71,19 +80,6 @@
         "value": 0
       },
       "direct_transition": "Hospital_Encounter_Delay"
-    },
-    "Medication_End": {
-      "type": "Simple",
-      "distributed_transition": [
-        {
-          "transition": "Terminal",
-          "distribution": 0.01
-        },
-        {
-          "transition": "Hospital_Encounter_Delay",
-          "distribution": 0.99
-        }
-      ]
     },
     "Hospital_Encounter_Delay": {
       "type": "Delay",

--- a/src/main/resources/modules/EXM506-r4.json
+++ b/src/main/resources/modules/EXM506-r4.json
@@ -1,0 +1,160 @@
+{
+  "name": "EXM506-r4",
+  "remarks": [
+    "define \"Initial Population\":",
+    "\"Encounter with an Opioid or Benzodiazepine at Discharge\"",
+    "",
+    "define \"Denominator\":",
+    "\"Initial Population\"",
+    "",
+    "define \"Numerator\":",
+    " \"Encounter with Two or More Concurrent Opioids at Discharge\"",
+    " union \"Encounter with a Concurrent Opioid and Benzodiazepine at Discharge\""
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Age_Guard"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "IPP_Encounter": {
+      "type": "Encounter",
+      "encounter_class": "ambulatory",
+      "reason": "",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 32485007,
+          "display": "Hospital admission (procedure)"
+        }
+      ],
+      "direct_transition": "Order_Med",
+      "remarks": [
+        "define \"Inpatient Encounter with Age Greater than or Equal to 18\":",
+        "  Global.\"Inpatient Encounter\" EncounterInpatient",
+        "     with [\"Patient\"] BirthDate",
+        "       such that Global.CalendarAgeInYearsAt(FHIRHelpers.ToDate(Patient.birthDate), start of FHIRHelpers.ToInterval(EncounterInpatient.period)) >= 18"
+      ]
+    },
+    "Medication_Discharge_Opiod": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 1010600,
+          "display": "Buprenorphine 2 MG / Naloxone 0.5 MG Oral Strip"
+        }
+      ],
+      "direct_transition": "Med_Delay",
+      "administration": false,
+      "assign_to_attribute": "discharge_med",
+      "remarks": [
+        "define \"Opioid at Discharge\":",
+        "  [\"MedicationRequest\": \"Schedule II and Schedule III Opioids\"] OpioidsDischarge",
+        "      where exists (OpioidsDischarge.category C where FHIRHelpers.ToConcept(C) ~ \"Discharge\")",
+        "          and OpioidsDischarge.intent = 'plan'"
+      ]
+    },
+    "Hospital_Stay_End": {
+      "type": "EncounterEnd",
+      "direct_transition": "Medication_End"
+    },
+    "Age_Guard": {
+      "type": "Guard",
+      "allow": {
+        "condition_type": "Age",
+        "operator": ">=",
+        "quantity": 18,
+        "unit": "years",
+        "value": 0
+      },
+      "direct_transition": "Hospital_Encounter_Delay"
+    },
+    "Medication_End": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Terminal",
+          "distribution": 0.01
+        },
+        {
+          "transition": "Hospital_Encounter_Delay",
+          "distribution": 0.99
+        }
+      ]
+    },
+    "Hospital_Encounter_Delay": {
+      "type": "Delay",
+      "range": {
+        "low": 0,
+        "high": 3,
+        "unit": "years"
+      },
+      "direct_transition": "IPP_Encounter"
+    },
+    "Medication_Discharge_Benzodiazepine": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 1298088,
+          "display": "Flurazepam Hydrochloride 15 MG Oral Capsule"
+        }
+      ],
+      "direct_transition": "Med_Delay",
+      "assign_to_attribute": "discharge_med",
+      "remarks": [
+        "define \"Benzodiazepine at Discharge\":",
+        "  [\"MedicationRequest\": \"Schedule IV Benzodiazepines\"] BenzodiazepineDischarge",
+        "      where exists (BenzodiazepineDischarge.category C where FHIRHelpers.ToConcept(C) ~ \"Discharge\")",
+        "          and BenzodiazepineDischarge.intent = 'plan'"
+      ]
+    },
+    "Order_Med": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Medication_Discharge_Opiod",
+          "distribution": 0.5
+        },
+        {
+          "transition": "Medication_Discharge_Benzodiazepine",
+          "distribution": 0.5
+        }
+      ]
+    },
+    "Hospital_Stay_Delay": {
+      "type": "Delay",
+      "exact": {
+        "quantity": 1,
+        "unit": "days"
+      },
+      "direct_transition": "Order_Med"
+    },
+    "Med_Delay": {
+      "type": "Delay",
+      "range": {
+        "low": 1,
+        "high": 2,
+        "unit": "hours"
+      },
+      "direct_transition": "End_Discharge_Med"
+    },
+    "End_Discharge_Med": {
+      "type": "MedicationEnd",
+      "distributed_transition": [
+        {
+          "transition": "Hospital_Stay_End",
+          "distribution": 0.2
+        },
+        {
+          "transition": "Hospital_Stay_Delay",
+          "distribution": 0.8
+        }
+      ],
+      "referenced_by_attribute": "discharge_med"
+    }
+  }
+}


### PR DESCRIPTION
*Note*: In this PR, I also get rid of the usage of `valueset` in the EXM130 module, as there will be an error during patient gen in fhir-patient-generator if the `terminology` directory doesn't exist. There is a way around this, but I'm going to reflect it in future tasking.

![image](https://user-images.githubusercontent.com/16297930/80130916-63c1ea80-8567-11ea-8f0f-d956ec5b5f56.png)
