### PR TITLE
use valuesets for EXM130-r4 module

### DIFF
--- a/src/main/resources/modules/EXM130-r4.json
+++ b/src/main/resources/modules/EXM130-r4.json
@@ -41,13 +41,10 @@
         ],
         "type": "Encounter",
         "encounter_class": "ambulatory",
-        "codes": [
-          {
-              "system": "http://snomed.info/sct",
-              "code": "185465003",
-              "display": "Weekend visit (procedure)"
-          }
-        ],
+        "valueset": {
+          "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001",
+          "display": "Office Visit"
+        },
         "distributed_transition": [
           {
             "distribution": 0.5,
@@ -69,13 +66,10 @@
           "  and Global.'Normalize Onset'(Colonoscopy.performed) ends 10 years or less on or before end of 'Measurement Period'",
           "============================================================================================================================"
         ],
-        "codes": [
-          {
-            "system": "SNOMED-CT",
-            "code": "73761001",
-            "display": "Colonoscopy"
-          }
-        ],
+        "valueset": {
+          "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020",
+          "display": "Colonoscopy"
+        },
         "direct_transition": "Terminal"
       },
       "Terminal": {


### PR DESCRIPTION
For the two states that we use a code for, Encounter and Procedure, use a valueset instead. I just picked one from the CQL:

Encounter:

``` CQL
valueset "Office Visit": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001'
```

Procedure:

``` CQL
valueset "Colonoscopy": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020'
```

----

To test, I recommend generating some patients and inspecting the output:

```
./run_synthea -p 10 -m EXM130-r4 -a 51-51
```

One easy way to look at the output is to use Dylan's [record viewer](https://dehall.github.io/spt/public/record_viewer.html). You can drag and drop the patient bundles into the record viewer. You should see various codes selected for colonoscopy or for outpatient visit. E.g.:

![image](https://user-images.githubusercontent.com/16297930/81095644-5398fc00-8ed3-11ea-8639-5095bc82594e.png)

![image](https://user-images.githubusercontent.com/16297930/81095720-6d3a4380-8ed3-11ea-8e06-354293617b1d.png)
