### PR TITLE
Add R4 support for export of additionalAttributes

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -1418,7 +1418,8 @@ public class FhirR4 {
     condition.fullUrl = conditionEntry.getFullUrl();
 
     if (condition.additionalAttributes != null) {
-      conditionEntry.setResource(setAdditionalAttributes(conditionResource, condition.additionalAttributes));
+      conditionEntry.setResource(setAdditionalAttributes(
+        conditionResource, condition.additionalAttributes));
     }
     return conditionEntry;
   }
@@ -1478,7 +1479,8 @@ public class FhirR4 {
     allergy.fullUrl = allergyEntry.getFullUrl();
 
     if (allergy.additionalAttributes != null) {
-      allergyEntry.setResource(setAdditionalAttributes(allergyResource, allergy.additionalAttributes));
+      allergyEntry.setResource(setAdditionalAttributes(
+        allergyResource, allergy.additionalAttributes));
     }
     return allergyEntry;
   }
@@ -1577,7 +1579,8 @@ public class FhirR4 {
     BundleEntryComponent entry = newEntry(bundle, observationResource);
     observation.fullUrl = entry.getFullUrl();
     if (observation.additionalAttributes != null) {
-      entry.setResource(setAdditionalAttributes(observationResource, observation.additionalAttributes));
+      entry.setResource(setAdditionalAttributes(
+        observationResource, observation.additionalAttributes));
     }
     return entry;
   }
@@ -1683,7 +1686,8 @@ public class FhirR4 {
     procedure.fullUrl = procedureEntry.getFullUrl();
 
     if (procedure.additionalAttributes != null) {
-      procedureEntry.setResource(setAdditionalAttributes(procedureResource, procedure.additionalAttributes));
+      procedureEntry.setResource(setAdditionalAttributes(
+        procedureResource, procedure.additionalAttributes));
     }
     return procedureEntry;
   }
@@ -1994,7 +1998,8 @@ public class FhirR4 {
     }
 
     if (medication.additionalAttributes != null) {
-      medicationEntry.setResource(setAdditionalAttributes(medicationResource, medication.additionalAttributes));
+      medicationEntry.setResource(setAdditionalAttributes(
+        medicationResource, medication.additionalAttributes));
     }
 
     return medicationEntry;
@@ -2117,7 +2122,8 @@ public class FhirR4 {
     }
 
     if (report.additionalAttributes != null) {
-      reportResource = (DiagnosticReport)setAdditionalAttributes(reportResource, report.additionalAttributes);
+      reportResource = (DiagnosticReport)setAdditionalAttributes(
+        reportResource, report.additionalAttributes);
     }
     return newEntry(bundle, reportResource);
   }
@@ -2312,7 +2318,8 @@ public class FhirR4 {
         .setDiv(new XhtmlNode(NodeType.Element).setValue(narrative)));
 
     if (carePlan.additionalAttributes != null) {
-      careplanResource = (org.hl7.fhir.r4.model.CarePlan)setAdditionalAttributes(careplanResource, carePlan.additionalAttributes);
+      careplanResource = (org.hl7.fhir.r4.model.CarePlan)setAdditionalAttributes(
+        careplanResource, carePlan.additionalAttributes);
     }
     return newEntry(bundle, careplanResource);
   }
@@ -2921,7 +2928,7 @@ public class FhirR4 {
    * @return A new Resource object with the additional attributes, or the original
    * Resource object if the attributes cannot be successfully applied
    */
-  private static Resource setAdditionalAttributes(Resource resource, JsonObject additionalAttributes) {
+  static Resource setAdditionalAttributes(Resource resource, JsonObject additionalAttributes) {
     // Serialize the resource to JSON
     IParser parser = FHIR_CTX.newJsonParser();
     String encSer = parser.encodeResourceToString(resource);

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -1419,7 +1419,7 @@ public class FhirR4 {
 
     if (condition.additionalAttributes != null) {
       conditionEntry.setResource(setAdditionalAttributes(
-        conditionResource, condition.additionalAttributes));
+          conditionResource, condition.additionalAttributes));
     }
     return conditionEntry;
   }
@@ -1480,7 +1480,7 @@ public class FhirR4 {
 
     if (allergy.additionalAttributes != null) {
       allergyEntry.setResource(setAdditionalAttributes(
-        allergyResource, allergy.additionalAttributes));
+          allergyResource, allergy.additionalAttributes));
     }
     return allergyEntry;
   }
@@ -1580,7 +1580,7 @@ public class FhirR4 {
     observation.fullUrl = entry.getFullUrl();
     if (observation.additionalAttributes != null) {
       entry.setResource(setAdditionalAttributes(
-        observationResource, observation.additionalAttributes));
+          observationResource, observation.additionalAttributes));
     }
     return entry;
   }
@@ -1687,7 +1687,7 @@ public class FhirR4 {
 
     if (procedure.additionalAttributes != null) {
       procedureEntry.setResource(setAdditionalAttributes(
-        procedureResource, procedure.additionalAttributes));
+          procedureResource, procedure.additionalAttributes));
     }
     return procedureEntry;
   }
@@ -1999,7 +1999,7 @@ public class FhirR4 {
 
     if (medication.additionalAttributes != null) {
       medicationEntry.setResource(setAdditionalAttributes(
-        medicationResource, medication.additionalAttributes));
+          medicationResource, medication.additionalAttributes));
     }
 
     return medicationEntry;
@@ -2926,7 +2926,7 @@ public class FhirR4 {
    * @param resource The resource to which the attributes apply
    * @param additionalAttributes The attributes to apply
    * @return A new Resource object with the additional attributes, or the original
-   * Resource object if the attributes cannot be successfully applied
+   *    Resource object if the attributes cannot be successfully applied
    */
   static Resource setAdditionalAttributes(Resource resource, JsonObject additionalAttributes) {
     // Serialize the resource to JSON

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -1,6 +1,8 @@
 package org.mitre.synthea.export;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.DataFormatException;
+import ca.uhn.fhir.parser.IParser;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import com.google.gson.Gson;
@@ -768,7 +770,11 @@ public class FhirR4 {
           .setSystem("https://github.com/synthetichealth/synthea")
           .setValue(encounterResource.getId());
     }
-    return entry;
+
+    if (encounter.additionalAttributes != null) {
+      entry.setResource(setAdditionalAttributes(encounterResource, encounter.additionalAttributes));
+    }
+      return entry;
   }
 
   /**
@@ -1411,6 +1417,9 @@ public class FhirR4 {
 
     condition.fullUrl = conditionEntry.getFullUrl();
 
+    if (condition.additionalAttributes != null) {
+      conditionEntry.setResource(setAdditionalAttributes(conditionResource, condition.additionalAttributes));
+    }
     return conditionEntry;
   }
 
@@ -1467,6 +1476,10 @@ public class FhirR4 {
     }
     BundleEntryComponent allergyEntry = newEntry(bundle, allergyResource);
     allergy.fullUrl = allergyEntry.getFullUrl();
+
+    if (allergy.additionalAttributes != null) {
+      allergyEntry.setResource(setAdditionalAttributes(allergyResource, allergy.additionalAttributes));
+    }
     return allergyEntry;
   }
 
@@ -1563,6 +1576,9 @@ public class FhirR4 {
 
     BundleEntryComponent entry = newEntry(bundle, observationResource);
     observation.fullUrl = entry.getFullUrl();
+    if (observation.additionalAttributes != null) {
+      entry.setResource(setAdditionalAttributes(observationResource, observation.additionalAttributes));
+    }
     return entry;
   }
 
@@ -1666,6 +1682,9 @@ public class FhirR4 {
     BundleEntryComponent procedureEntry = newEntry(bundle, procedureResource);
     procedure.fullUrl = procedureEntry.getFullUrl();
 
+    if (procedure.additionalAttributes != null) {
+      procedureEntry.setResource(setAdditionalAttributes(procedureResource, procedure.additionalAttributes));
+    }
     return procedureEntry;
   }
 
@@ -1974,6 +1993,10 @@ public class FhirR4 {
       medicationAdministration(personEntry, bundle, encounterEntry, medication, medicationResource);
     }
 
+    if (medication.additionalAttributes != null) {
+      medicationEntry.setResource(setAdditionalAttributes(medicationResource, medication.additionalAttributes));
+    }
+
     return medicationEntry;
   }
 
@@ -2093,6 +2116,9 @@ public class FhirR4 {
       reportResource.addResult(reference);
     }
 
+    if (report.additionalAttributes != null) {
+      reportResource = (DiagnosticReport)setAdditionalAttributes(reportResource, report.additionalAttributes);
+    }
     return newEntry(bundle, reportResource);
   }
 
@@ -2285,6 +2311,9 @@ public class FhirR4 {
     careplanResource.setText(new Narrative().setStatus(NarrativeStatus.GENERATED)
         .setDiv(new XhtmlNode(NodeType.Element).setValue(narrative)));
 
+    if (carePlan.additionalAttributes != null) {
+      careplanResource = (org.hl7.fhir.r4.model.CarePlan)setAdditionalAttributes(careplanResource, carePlan.additionalAttributes);
+    }
     return newEntry(bundle, careplanResource);
   }
 
@@ -2881,6 +2910,42 @@ public class FhirR4 {
     }
 
     return entry;
+  }
+
+  /**
+   * Apply any additional attributes to a resource. Each attribute must be valid FHIR JSON.
+   * If an additionalAttribute specified already has a value on the resource, the existing
+   * value will be overwritten.
+   * @param resource The resource to which the attributes apply
+   * @param additionalAttributes The attributes to apply
+   * @return A new Resource object with the additional attributes
+   */
+  private static Resource setAdditionalAttributes(Resource resource, JsonObject additionalAttributes) {
+    // Serialize the resource to JSON
+    IParser parser = FHIR_CTX.newJsonParser();
+    String encSer = parser.encodeResourceToString(resource);
+    Gson gson = new Gson();
+    JsonElement je = gson.fromJson(encSer, JsonElement.class);
+    JsonObject jo = je.getAsJsonObject();
+
+    // Add each addtional attribute by manipulating the JSON. Overwrite any existing values.
+    // This is done with JSON manipulation, rather than parsing the attribute JSON directly,
+    // because the FHIR library only exposes a method to parse a FHIR Resource, and the attributes
+    // can be of any FHIR type.
+    for (java.util.Map.Entry<String, JsonElement> e : additionalAttributes.entrySet()) {
+      jo.remove(e.getKey());
+      jo.add(e.getKey(), e.getValue());
+    }
+
+    // Parse the JSON object back into a Resource object
+    try {
+      return parser.parseResource(resource.getClass(), jo.toString());
+    } catch (DataFormatException e) {
+      // Parsing failed, so just return the original resource
+      System.err.println("ERROR: Unable apply additionalAttributes. " + e.getMessage());
+      e.printStackTrace();
+      return resource;
+    }
   }
 
   /**

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -774,7 +774,7 @@ public class FhirR4 {
     if (encounter.additionalAttributes != null) {
       entry.setResource(setAdditionalAttributes(encounterResource, encounter.additionalAttributes));
     }
-      return entry;
+    return entry;
   }
 
   /**
@@ -2918,7 +2918,8 @@ public class FhirR4 {
    * value will be overwritten.
    * @param resource The resource to which the attributes apply
    * @param additionalAttributes The attributes to apply
-   * @return A new Resource object with the additional attributes
+   * @return A new Resource object with the additional attributes, or the original
+   * Resource object if the attributes cannot be successfully applied
    */
   private static Resource setAdditionalAttributes(Resource resource, JsonObject additionalAttributes) {
     // Serialize the resource to JSON
@@ -2933,7 +2934,6 @@ public class FhirR4 {
     // because the FHIR library only exposes a method to parse a FHIR Resource, and the attributes
     // can be of any FHIR type.
     for (java.util.Map.Entry<String, JsonElement> e : additionalAttributes.entrySet()) {
-      jo.remove(e.getKey());
       jo.add(e.getKey(), e.getValue());
     }
 

--- a/src/test/java/org/mitre/synthea/export/AdditionalAttributesTest.java
+++ b/src/test/java/org/mitre/synthea/export/AdditionalAttributesTest.java
@@ -1,0 +1,64 @@
+package org.mitre.synthea.export;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Encounter;
+import org.junit.Test;
+
+/**
+ * Unit tests for adding additional attributes in R4 export
+ */
+public class AdditionalAttributesTest {
+    @Test
+    public void testAdditionalAttributesExport() {
+        JsonObject additionalAttributes = parseJsonFixture("src/test/resources/export/additional_attributes_encounter.json");
+        Encounter encounter = new Encounter();
+        encounter = (Encounter)FhirR4.setAdditionalAttributes(encounter, additionalAttributes);
+        CodeableConcept priority = encounter.getPriority();
+        assertNotNull(priority);
+        List<Coding> coding = priority.getCoding();
+        assertNotNull(coding);
+        Coding firstCoding = coding.get(0);
+        assertNotNull(firstCoding);
+        assertEquals(firstCoding.getSystem(), "http://snomed.info/sct");
+        assertEquals(firstCoding.getCode(), "260385009");
+        assertEquals(firstCoding.getDisplay(), "Negative");
+        assertEquals(firstCoding.getUserSelected(), true);
+        assertEquals(priority.getText(), "THIS IS A TEST VALUE FOR PRIORITY");
+    }
+
+    @Test
+    public void testInvalidAdditionalAttributesExport() {
+        JsonObject additionalAttributes = parseJsonFixture("src/test/resources/export/additional_attributes_encounter_invalid.json");
+        Encounter encounter = new Encounter();
+        Encounter encounter2 = (Encounter)FhirR4.setAdditionalAttributes(encounter, additionalAttributes);
+        assertTrue(encounter2.equals(encounter));
+    }
+
+    private JsonObject parseJsonFixture(String filePath) {
+        Path fixturePath = Paths.get(filePath);
+        String fixtureJson = "";
+        try {
+            byte[] encoded = Files.readAllBytes(fixturePath);
+            fixtureJson = new String(encoded);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
+        JsonParser parser = new JsonParser();
+        return parser.parse(fixtureJson).getAsJsonObject();
+    }
+}

--- a/src/test/java/org/mitre/synthea/export/AdditionalAttributesTest.java
+++ b/src/test/java/org/mitre/synthea/export/AdditionalAttributesTest.java
@@ -5,13 +5,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
@@ -19,46 +19,49 @@ import org.hl7.fhir.r4.model.Encounter;
 import org.junit.Test;
 
 /**
- * Unit tests for adding additional attributes in R4 export
+ * Unit tests for adding additional attributes in R4 export.
  */
 public class AdditionalAttributesTest {
-    @Test
-    public void testAdditionalAttributesExport() {
-        JsonObject additionalAttributes = parseJsonFixture("src/test/resources/export/additional_attributes_encounter.json");
-        Encounter encounter = new Encounter();
-        encounter = (Encounter)FhirR4.setAdditionalAttributes(encounter, additionalAttributes);
-        CodeableConcept priority = encounter.getPriority();
-        assertNotNull(priority);
-        List<Coding> coding = priority.getCoding();
-        assertNotNull(coding);
-        Coding firstCoding = coding.get(0);
-        assertNotNull(firstCoding);
-        assertEquals(firstCoding.getSystem(), "http://snomed.info/sct");
-        assertEquals(firstCoding.getCode(), "260385009");
-        assertEquals(firstCoding.getDisplay(), "Negative");
-        assertEquals(firstCoding.getUserSelected(), true);
-        assertEquals(priority.getText(), "THIS IS A TEST VALUE FOR PRIORITY");
+  @Test
+  public void testAdditionalAttributesExport() {
+    JsonObject additionalAttributes = parseJsonFixture(
+        "src/test/resources/export/additional_attributes_encounter.json");
+    Encounter encounter = new Encounter();
+    encounter = (Encounter)FhirR4.setAdditionalAttributes(encounter, additionalAttributes);
+    CodeableConcept priority = encounter.getPriority();
+    assertNotNull(priority);
+    List<Coding> coding = priority.getCoding();
+    assertNotNull(coding);
+    Coding firstCoding = coding.get(0);
+    assertNotNull(firstCoding);
+    assertEquals(firstCoding.getSystem(), "http://snomed.info/sct");
+    assertEquals(firstCoding.getCode(), "260385009");
+    assertEquals(firstCoding.getDisplay(), "Negative");
+    assertEquals(firstCoding.getUserSelected(), true);
+    assertEquals(priority.getText(), "THIS IS A TEST VALUE FOR PRIORITY");
+  }
+
+  @Test
+  public void testInvalidAdditionalAttributesExport() {
+    JsonObject additionalAttributes = parseJsonFixture(
+        "src/test/resources/export/additional_attributes_encounter_invalid.json");
+    Encounter encounter = new Encounter();
+    Encounter encounter2 = (Encounter)FhirR4.setAdditionalAttributes(
+        encounter, additionalAttributes);
+    assertTrue(encounter2.equals(encounter));
+  }
+
+  private JsonObject parseJsonFixture(String filePath) {
+    Path fixturePath = Paths.get(filePath);
+    String fixtureJson = "";
+    try {
+      byte[] encoded = Files.readAllBytes(fixturePath);
+      fixtureJson = new String(encoded);
+    } catch (Exception e) {
+      fail(e.getMessage());
     }
 
-    @Test
-    public void testInvalidAdditionalAttributesExport() {
-        JsonObject additionalAttributes = parseJsonFixture("src/test/resources/export/additional_attributes_encounter_invalid.json");
-        Encounter encounter = new Encounter();
-        Encounter encounter2 = (Encounter)FhirR4.setAdditionalAttributes(encounter, additionalAttributes);
-        assertTrue(encounter2.equals(encounter));
-    }
-
-    private JsonObject parseJsonFixture(String filePath) {
-        Path fixturePath = Paths.get(filePath);
-        String fixtureJson = "";
-        try {
-            byte[] encoded = Files.readAllBytes(fixturePath);
-            fixtureJson = new String(encoded);
-        } catch (Exception e) {
-            fail(e.getMessage());
-        }
-
-        JsonParser parser = new JsonParser();
-        return parser.parse(fixtureJson).getAsJsonObject();
-    }
+    JsonParser parser = new JsonParser();
+    return parser.parse(fixtureJson).getAsJsonObject();
+  }
 }

--- a/src/test/resources/export/additional_attributes_encounter.json
+++ b/src/test/resources/export/additional_attributes_encounter.json
@@ -1,0 +1,13 @@
+{
+    "priority": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "260385009",
+                "display": "Negative",
+                "userSelected": true
+            }
+        ],
+        "text": "THIS IS A TEST VALUE FOR PRIORITY"
+    }
+}

--- a/src/test/resources/export/additional_attributes_encounter_invalid.json
+++ b/src/test/resources/export/additional_attributes_encounter_invalid.json
@@ -1,0 +1,13 @@
+{
+    "priority": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "260385009",
+                "display": "Negative",
+                "userSelected": "this is supposed to be a boolean"
+            }
+        ],
+        "text": "THIS IS A TEST VALUE FOR PRIORITY"
+    }
+}


### PR DESCRIPTION
### Summary
This adds support for export of `additionalAttributes`, which is a continuation of the work started in https://github.com/projecttacoma/synthea/pull/17.

### New Behavior
- Attributes specified in `additionalAttributes` in the module will be propagated to corresponding FHIR resource in the FHIR bundles exported from synthea.
- If the `additionalAttributes` contains any malformed JSON, it will effectively just be ignored for that state. An error message and a stack trace will print, but the program is allowed to continue, behaving as if no additional attributes were specified.
- This new behavior only exists for FHIR R4.

### Code Changes

- Changes are contained to the `FhirR4` exporter class.
- The implementation might seem a little odd. It's different from my initial approach, and it's explained somewhat in the code comments. Basically, what I first tried to do was parse the additional attributes to FHIR objects, and then just set the value for the corresponding property on the FHIR resource Java object. Ultimately I gave up on that approach, because as far as I could tell there was no simple way to do that parsing for any possible data type. Instead, I serialize the FHIR resource to JSON, set the additional attributes by just modifying the JSON directly, and then parse the resource back into a Java object. It essentially boils down to the fact that it's easy to parse whole FHIR resources, but not individual properties of those resources.

### Testing

- Try adding `additionalAttributes` to any state of your favorite module, running that module, and checking the exported bundles for the attributes.
- As an example, here's a separate branch I used for testing with EXM130: https://github.com/projecttacoma/synthea/compare/additional_attributes_export...projecttacoma:test_additional_attributes_export
  - If you use EXM130, you'll need to add [this ValueSet bundle](https://github.com/DBCG/connectathon/blob/master/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/valuesets-EXM130_FHIR4-7.2.000-bundle.json) to /src/main/resources/terminology
- Use some malformed JSON, like putting an integer for a boolean value, and verify that you get the expected failure behavior described above.