### PR TITLE
Measurement period config

### DIFF
--- a/src/main/resources/modules/EXM125-8.0.000-r4.json
+++ b/src/main/resources/modules/EXM125-8.0.000-r4.json
@@ -6,6 +6,13 @@
     "states": {
       "Initial": {
         "type": "Initial",
+        "direct_transition": "Set_Measurement_Period"
+      },
+      "Set_Measurement_Period": {
+        "type": "SetAttribute",
+        "attribute": "Start of Measurement Period",
+        "value": "2019-01-01T00:00:00Z",
+        "config_key": "ecqm.measurementPeriodStart",
         "direct_transition": "IPP_Age_Guard"
       },
       "IPP_Age_Guard": {
@@ -26,7 +33,7 @@
               "condition": {
                 "condition_type": "Date",
                 "operator": ">=",
-                "year": 2019
+                "attribute": "Start of Measurement Period"
               },
               "transition": "IPP_Qualifying_Encounter"
             }

--- a/src/main/resources/modules/EXM125-8.0.000-r4.json
+++ b/src/main/resources/modules/EXM125-8.0.000-r4.json
@@ -13,6 +13,16 @@
         "attribute": "Start of Measurement Period",
         "value": "2019-01-01T00:00:00Z",
         "config_key": "ecqm.measurementPeriodStart",
+        "direct_transition": "Measurement_Period_Guard"
+      },
+      "Measurement_Period_Guard": {
+        "type": "Guard",
+        "remarks": [],
+        "allow": {
+          "condition_type": "Date",
+          "operator": ">=",
+          "attribute": "Start of Measurement Period"
+        },
         "direct_transition": "IPP_Age_Guard"
       },
       "IPP_Age_Guard": {
@@ -28,16 +38,7 @@
           "quantity": 52,
           "unit": "years"
         },
-        "conditional_transition": [
-            {
-              "condition": {
-                "condition_type": "Date",
-                "operator": ">=",
-                "attribute": "Start of Measurement Period"
-              },
-              "transition": "IPP_Qualifying_Encounter"
-            }
-        ]
+        "direct_transition": "IPP_Qualifying_Encounter"
       },
       "IPP_Qualifying_Encounter": {
         "remarks": [

--- a/src/main/resources/modules/EXM130-8.0.000-r4.json
+++ b/src/main/resources/modules/EXM130-8.0.000-r4.json
@@ -7,7 +7,7 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "NUMER_Date_Guard"
+      "direct_transition": "Set_Measurement_Period"
     },
     "IPP_Qualifying_Encounter": {
       "remarks": [
@@ -43,48 +43,30 @@
       "type": "Terminal"
     },
     "wait_for_mp_for_encounter": {
-      "type": "Guard",
-      "allow": {
-        "condition_type": "Date",
-        "operator": "==",
-        "year": 2019,
-        "value": 0
-      },
-      "distributed_transition": [
+      "type": "Simple",
+      "conditional_transition": [
         {
-          "transition": "delay_in_mp",
-          "distribution": 0.75
+          "transition": "IPP_Qualifying_Encounter",
+          "condition": {
+            "condition_type": "Date",
+            "operator": ">=",
+            "attribute": "Start of Measurement Period"
+          }
         },
         {
-          "transition": "Terminal",
-          "distribution": 0.25
+          "transition": "NUMER_delay"
         }
       ]
     },
     "NUMER_delay": {
       "type": "Delay",
-      "direct_transition": "NUMER_Colonoscopy_Performed",
-      "range": {
-        "low": 1,
-        "high": 10,
+      "exact": {
+        "quantity": 1,
         "unit": "years"
-      }
-    },
-    "NUMER_Date_Guard": {
-      "type": "Guard",
-      "allow": {
-        "condition_type": "Date",
-        "operator": ">",
-        "year": 2009
       },
-      "remarks": [
-        "====================================================================================================================",
-        "Global.CalendarAgeInYearsAt(FHIRHelpers.ToDate(Patient.birthDate), start of Measurement Period) in Interval[50, 75]",
-        "===================================================================================================================="
-      ],
       "distributed_transition": [
         {
-          "transition": "NUMER_delay",
+          "transition": "NUMER_Colonoscopy_Performed",
           "distribution": 0.75
         },
         {
@@ -93,14 +75,12 @@
         }
       ]
     },
-    "delay_in_mp": {
-      "type": "Delay",
-      "direct_transition": "IPP_Qualifying_Encounter",
-      "range": {
-        "low": 1,
-        "high": 365,
-        "unit": "days"
-      }
+    "Set_Measurement_Period": {
+      "type": "SetAttribute",
+      "attribute": "Start of Measurement Period",
+      "value": "2019-01-01T00:00:00Z",
+      "config_key": "ecqm.measurementPeriodStart",
+      "direct_transition": "NUMER_delay"
     }
   }
 }

--- a/src/main/resources/modules/EXM130-8.0.000-r4.json
+++ b/src/main/resources/modules/EXM130-8.0.000-r4.json
@@ -44,34 +44,49 @@
     },
     "wait_for_mp_for_encounter": {
       "type": "Simple",
-      "conditional_transition": [
+      "complex_transition": [
         {
-          "transition": "IPP_Qualifying_Encounter",
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
             "attribute": "Start of Measurement Period"
-          }
+          },
+          "distributions": [
+            {
+              "transition": "IPP_Qualifying_Encounter",
+              "distribution": 0.90
+            },
+            {
+              "transition": "Terminal",
+              "distribution": 0.10
+            }
+          ]
         },
         {
-          "transition": "NUMER_delay"
+          "distributions": [
+            {
+              "transition": "NUMER_delay",
+              "distribution": 1
+            }
+          ]
         }
       ]
     },
     "NUMER_delay": {
       "type": "Delay",
-      "exact": {
-        "quantity": 1,
-        "unit": "years"
+      "range": {
+        "low": 3,
+        "high": 9,
+        "unit": "months"
       },
       "distributed_transition": [
         {
           "transition": "NUMER_Colonoscopy_Performed",
-          "distribution": 0.75
+          "distribution": 0.05
         },
         {
           "transition": "wait_for_mp_for_encounter",
-          "distribution": 0.25
+          "distribution": 0.95
         }
       ]
     },


### PR DESCRIPTION
update exm125 and exm130 to include measurement year guards. The other measures work without it.