### PR TITLE
Terminology mockfile creation

### DIFF
--- a/src/main/java/org/mitre/synthea/helpers/ValueSetResolver.java
+++ b/src/main/java/org/mitre/synthea/helpers/ValueSetResolver.java
@@ -83,7 +83,7 @@ public class ValueSetResolver {
     this.vsetBundle.setEntry(entries);
   }
 
-  private String matchOid(String input) {
+  public static String matchOid(String input) {
     if (input == null) {
       return null;
     }

--- a/src/main/java/org/mitre/synthea/world/concepts/Terminology.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/Terminology.java
@@ -1,6 +1,5 @@
 package org.mitre.synthea.world.concepts;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/resources/templates/ccda/code_oid_lookup.ftl
+++ b/src/main/resources/templates/ccda/code_oid_lookup.ftl
@@ -1,11 +1,11 @@
 <#macro oid_for_code_system system>
-<#if system == "LOINC">
+<#if system == "LOINC" || system == "http://loinc.org">
 2.16.840.1.113883.6.1<#t>
-<#elseif system == "SNOMED-CT">
+<#elseif system == "SNOMED-CT" || system == "http://snomed.info/sct">
 2.16.840.1.113883.6.96<#t>
 <#elseif system == "CPT">
 2.16.840.1.113883.6.12<#t>
-<#elseif system == "RxNorm">
+<#elseif system == "RxNorm" || system == "http://www.nlm.nih.gov/research/umls/rxnorm">
 2.16.840.1.113883.6.88<#t>
 <#elseif system == "ICD-9-CM">
 2.16.840.1.113883.6.103<#t>

--- a/src/test/java/AppTest.java
+++ b/src/test/java/AppTest.java
@@ -24,6 +24,7 @@ public class AppTest {
   @BeforeClass
   public static void testSetup() throws Exception {
     TestHelper.loadTestProperties();
+    TestHelper.generateValuesetTempfiles();
     testStateDefault = Config.get("test_state.default", "Massachusetts");
     testTownDefault = Config.get("test_town.default", "Bedford");
     testStateAlternative = Config.get("test_state.alternative", "Utah");

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -1,19 +1,41 @@
 package org.mitre.synthea;
 
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.hl7.fhir.r4.model.ValueSet.ConceptReferenceComponent;
+import org.hl7.fhir.r4.model.ValueSet.ConceptSetComponent;
+import org.hl7.fhir.r4.model.ValueSet.ValueSetComposeComponent;
 import org.mitre.synthea.engine.Module;
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.ValueSetResolver;
 
 public abstract class TestHelper {
 
   /**
    * Returns a test fixture Module by filename.
+   * 
    * @param filename The filename of the test fixture Module.
    * @return A Module.
    * @throws Exception On errors.
@@ -26,6 +48,7 @@ public abstract class TestHelper {
 
   /**
    * Load the test.properties file.
+   * 
    * @throws Exception on configuration loading errors.
    */
   public static void loadTestProperties() throws Exception {
@@ -65,5 +88,96 @@ public abstract class TestHelper {
   public static long timestamp(int year, int month, int day, int hr, int min, int sec) {
     return LocalDateTime.of(year, month, day, hr, min, sec).toInstant(ZoneOffset.UTC)
         .toEpochMilli();
+  }
+
+  /**
+   * generateValuesetTempfiles is a static method that is intended to be called at the start of a
+   * Synthea test run. It parses the modules in the synthea module directory to get a unique list
+   * of valuesets that are required, and generates a bundle of mock valueset objects, one for each
+   * valueset URL, each of which contains one code.
+   * @throws IOException if the tempfile can't be created, or if a module can't be read
+   */
+  public static void generateValuesetTempfiles() throws IOException {
+    Path path = FileSystems.getDefault()
+                          .getPath("src", "main", "resources", "terminology")
+                          .toAbsolutePath();
+    Path file = Files.createTempFile(path, "TEMP_VS_FILE", ".json");
+
+    // This shutdown hook will delete the tempfile at the end of the test run
+    // or if the test is exited early (via Ctrl+c or other methods)
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        try {
+          Files.delete(file);
+        } catch (IOException ioe) {
+          ioe.printStackTrace();
+        }
+      }
+    });
+    Path modPath = FileSystems.getDefault()
+                              .getPath("src", "main", "resources", "modules")
+                              .toAbsolutePath();
+    Bundle valueSetBundle = new Bundle();
+    valueSetBundle.setId("TestValueSetBundle");
+    Files.list(modPath)
+        .filter(p -> !p.toFile().isDirectory())
+        .filter(p -> p.getFileName().toString().endsWith(".json")).flatMap(p -> getValueSetUrls(p))
+        .collect(Collectors.toSet()).forEach((vsUrl) -> {
+          valueSetBundle.addEntry(generateValuesetBundleEntry(vsUrl));
+        });
+    FhirContext ctx = FhirContext.forR4();
+    IParser parser = ctx.newJsonParser();
+    FileWriter vsFileWriter = new FileWriter(file.toFile());
+    parser.encodeResourceToWriter(valueSetBundle, vsFileWriter);
+  }
+
+  /**
+   * generateValuesetBundleEntry encapsulates the creation of the valueset bundle entry
+   * from the valueset URL.
+   * @param vsUrl String representing the URL of the valueset needing to be mocked
+   * @return a {@link BundleEntryComponent} containing a {@link ValueSet} object, to be added to
+   *         the bundle for the tempfile
+   */
+  private static BundleEntryComponent generateValuesetBundleEntry(String vsUrl) {
+    BundleEntryComponent bec = new BundleEntryComponent();
+    ValueSet valuesetObj = new ValueSet();
+    ValueSetComposeComponent vscc = new ValueSetComposeComponent();
+    ConceptSetComponent csc = new ConceptSetComponent();
+    ConceptReferenceComponent crc = new ConceptReferenceComponent();
+    crc.setCode("mock_code").setDisplay("mock_value");
+    csc.setSystem("http://snomed.info/sct").addConcept(crc);
+    vscc.addInclude(csc);
+    valuesetObj.setCompose(vscc).setUrl(vsUrl);
+    Identifier i = new Identifier();
+    i.setSystem("urn:ietf:rfc:3986");
+    String oid = ValueSetResolver.matchOid(vsUrl);
+    i.setValue(oid);
+    valuesetObj.setId(oid);
+    valuesetObj.addIdentifier(i).setName("TEST VALUESET");
+    bec.setResource(valuesetObj);
+    return bec;
+  }
+
+  /**
+   * getValueSetUrls takes in a path to a file, and returns a stream of valueset
+   * URLs from that file, which can be operated on further by a stream processing chain.
+   * 
+   * @param path a {@link java.nio.file.Path} object that points to a GMF JSON file
+   * @return A <code>Stream</code> of <code>String</code>s representing the
+   *         valueset URLs contained in the file (not deduplicated)
+   */
+  private static Stream<String> getValueSetUrls(Path path) {
+    try {
+      Pattern valueSetPattern = Pattern.compile("\"url\": ?\"(.+)\",");
+      Matcher matcher = valueSetPattern.matcher(Files.readString(path));
+      List<String> vs = new ArrayList<String>();
+      while (matcher.find()) {
+        vs.add(matcher.group(1));
+      }
+      return vs.stream();
+    } catch (IOException e) {
+      return null;
+    }
   }
 }

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -170,7 +170,7 @@ public abstract class TestHelper {
   private static Stream<String> getValueSetUrls(Path path) {
     try {
       Pattern valueSetPattern = Pattern.compile("\"url\": ?\"(.+)\",");
-      Matcher matcher = valueSetPattern.matcher(Files.readString(path));
+      Matcher matcher = valueSetPattern.matcher(readFile(path));
       List<String> vs = new ArrayList<String>();
       while (matcher.find()) {
         vs.add(matcher.group(1));
@@ -179,5 +179,10 @@ public abstract class TestHelper {
     } catch (IOException e) {
       return null;
     }
+  }
+
+  private static String readFile(Path path) throws IOException {
+    byte[] fileBytes = Files.readAllBytes(path);
+    return new String(fileBytes);
   }
 }

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -103,6 +103,8 @@ public abstract class TestHelper {
                           .toAbsolutePath();
     Path file = Files.createTempFile(path, "TEMP_VS_FILE", ".json");
 
+    System.err.println("Tempfile location: " + file.toAbsolutePath().toString());
+
     // This shutdown hook will delete the tempfile at the end of the test run
     // or if the test is exited early (via Ctrl+c or other methods)
     Runtime.getRuntime().addShutdownHook(new Thread() {

--- a/src/test/java/org/mitre/synthea/export/TextExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/TextExporterTest.java
@@ -23,6 +23,7 @@ public class TextExporterTest {
   @Test
   public void testTextExport() throws Exception {
     TestHelper.loadTestProperties();
+    TestHelper.generateValuesetTempfiles();
     Generator.DEFAULT_STATE = Config.get("test_state.default", "Massachusetts");
     File tempOutputFolder = tempFolder.newFolder();
     Config.set("exporter.baseDirectory", tempOutputFolder.toString());


### PR DESCRIPTION
Updated TestHelper to be able to create (and delete, when a test is finished) a mock bundle of valuesets in the src/main/resources/terminology directory, and called it in `AppTest` (always the first test to be run).

To test this: ensure `src/main/resources/terminology` is empty of any terminology JSON files, and run `./gradlew check`. A file should appear while the tests are running, and the tests should all pass. That file should be deleted after the tests finish.