### PR TITLE
104 clinical

### DIFF
--- a/src/main/resources/modules/stroke_exm_104_r4.json
+++ b/src/main/resources/modules/stroke_exm_104_r4.json
@@ -43,7 +43,7 @@
         "unit": "years",
         "value": 0
       },
-      "direct_transition": "Stroke_Delay"
+      "direct_transition": "Measurement_Period_Guard"
     },
     "Stroke_Delay": {
       "type": "Delay",
@@ -211,6 +211,16 @@
           "transition": "Second_Stroke"
         }
       ]
+    },
+    "Measurement_Period_Guard": {
+      "type": "Guard",
+      "allow": {
+        "condition_type": "Date",
+        "operator": "==",
+        "year": 2016,
+        "value": 0
+      },
+      "direct_transition": "Stroke_Delay"
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/stroke_exm_104_r4.json
+++ b/src/main/resources/modules/stroke_exm_104_r4.json
@@ -217,7 +217,7 @@
       "allow": {
         "condition_type": "Date",
         "operator": "==",
-        "year": 2016,
+        "year": 2019,
         "value": 0
       },
       "direct_transition": "Stroke_Delay"

--- a/src/main/resources/modules/stroke_exm_104_r4.json
+++ b/src/main/resources/modules/stroke_exm_104_r4.json
@@ -1,7 +1,8 @@
 {
   "name": "exm_104_r4",
   "remarks": [
-    "a non clinically-accurate stroke encounter module, for use with EXM104"
+    "a non clinically-accurate stroke encounter module, for use with EXM104",
+    "If the patient has already had a second stroke, transition to terminal."
   ],
   "states": {
     "Initial": {
@@ -134,11 +135,11 @@
       "distributed_transition": [
         {
           "transition": "Terminal",
-          "distribution": 0.01
+          "distribution": 0.8
         },
         {
-          "transition": "Stroke_Delay",
-          "distribution": 0.99
+          "transition": "Another_Stroke",
+          "distribution": 0.2
         }
       ],
       "medication_order": "Medication_discharge_antithrombotic"
@@ -187,6 +188,30 @@
         "high": 2,
         "unit": "hours"
       }
+    },
+    "Second_Stroke": {
+      "type": "SetAttribute",
+      "attribute": "second_stroke",
+      "direct_transition": "Stroke_Delay",
+      "value": true
+    },
+    "Another_Stroke": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "transition": "Terminal",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "second_stroke",
+            "operator": "==",
+            "value": true
+          }
+        },
+        {
+          "transition": "Second_Stroke"
+        }
+      ]
     }
-  }
+  },
+  "gmf_version": 2
 }


### PR DESCRIPTION
# Summary

This PR changes the module for EXM104 to limit the number of strokes to no more than 2 in order to make the module more clinically relevant.

## New behavior

The stroke_exm_104_r4.json module now limits strokes to no more than 2 and guards for the measurement year.

## Code changes

Adds boolean attribute to track whether the patient has already had a second stroke (and go to terminal if so):
<img width="671" alt="Screen Shot 2021-05-12 at 2 40 37 PM" src="https://user-images.githubusercontent.com/2643955/118027607-1c53fb00-b330-11eb-9bdd-f4830f582a3c.png">

Adds measurement year guard:
<img width="272" alt="Screen Shot 2021-05-12 at 2 40 25 PM" src="https://user-images.githubusercontent.com/2643955/118027596-19590a80-b330-11eb-9657-ea52d104c1de.png">

# Testing guidance

You can load the module and view in https://synthetichealth.github.io/module-builder/

Use the fhir-patient-generator to create patients. Point the synthea clone to this branch `104_clinical` and `make deep-clean` to use the latest module, or just replace the module in the fpg-local synthea that you already have cloned.

fpg Makefile change:
```
synthea:
	git clone --single-branch --branch 104_clinical https://github.com/projecttacoma/synthea.git
```

Run with command `make MEASURE_DIR=EXM_104-8.2.000 CALC_TYPE=fqm PATIENT_COUNT=1000`

Expected relevant patients: ~10%. Relevant patients should have 1-2 strokes (you can search for the module stroke codes to check).